### PR TITLE
Stream play issues

### DIFF
--- a/android/src/main/java/com/leblaaanc/RNStreamingKitManager/RNStreamingKitManagerModule.java
+++ b/android/src/main/java/com/leblaaanc/RNStreamingKitManager/RNStreamingKitManagerModule.java
@@ -92,7 +92,7 @@ MediaPlayer.OnErrorListener, MediaPlayer.OnBufferingUpdateListener {
   @ReactMethod
   public void play(String url)
   {
-    if (_isPaused) {
+    if (url == null && _isPaused) {
       startPlaying();
     } else {
      try {


### PR DESCRIPTION
The android play function will only resume now if paused and not provided with a url. This means we can now pass a url to play() and it will play the new stream instead of resuming the currently paused stream.

Fixes https://github.com/LeBlaaanc/react-native-streamingkit/issues/9