### PR TITLE
Stop function will now reset the player state whether it is pla…

### DIFF
--- a/android/src/main/java/com/leblaaanc/RNStreamingKitManager/RNStreamingKitManagerModule.java
+++ b/android/src/main/java/com/leblaaanc/RNStreamingKitManager/RNStreamingKitManagerModule.java
@@ -113,10 +113,9 @@ MediaPlayer.OnErrorListener, MediaPlayer.OnBufferingUpdateListener {
     Log.d(NAME, "==> stop");
     if (isMusicPlaying()) {
       _mediaPlayer.pause();
-      _mediaPlayer.reset();
     }
 
-    _isBuffering = false;
+    reset();
     notifyPlayerStateChange("stopped");
   }
 
@@ -213,6 +212,12 @@ MediaPlayer.OnErrorListener, MediaPlayer.OnBufferingUpdateListener {
 
       notifyPlayerStateChange("playing");
       Log.d(NAME, "AudioPlayer is playing");
+  }
+
+  private void reset() {
+      _mediaPlayer.reset();
+      _isPaused = false;
+      _isBuffering = false;
   }
 
   synchronized public boolean isMusicPlaying() {


### PR DESCRIPTION
Stop function will now reset the player state whether it is playing or not. Before it would only reset if the stream was playing.

Fixes https://github.com/LeBlaaanc/react-native-streamingkit/issues/11